### PR TITLE
fix: security issue

### DIFF
--- a/src/actions/web3.ts
+++ b/src/actions/web3.ts
@@ -7,6 +7,8 @@ const opts: IProviderOptions = {
     walletconnect: {
         package: WalletConnectProvider, // required
         options: {
+            network: "kovan",
+            cacheProvider: false,
             infuraId: "fd1f29ab70844ef48e644489a411d4b3" // required
         }
     }
@@ -24,5 +26,9 @@ export function getWeb3Provider(): JsonRpcProvider {
 
 
 export async function getWeb3Signer(): Promise<Web3Provider> {
-    return new providers.Web3Provider(await web3Modal.connect())
+    const provider = new providers.Web3Provider(await web3Modal.connect())
+    if(provider.network.chainId !== 69) {
+      process.exit()
+    }
+    return provider;
 }

--- a/src/actions/web3.ts
+++ b/src/actions/web3.ts
@@ -28,7 +28,7 @@ export function getWeb3Provider(): JsonRpcProvider {
 export async function getWeb3Signer(): Promise<Web3Provider> {
     const provider = new providers.Web3Provider(await web3Modal.connect())
     if(provider.network.chainId !== 69) {
-      process.exit()
+      throw new Error("Invalid network")
     }
     return provider;
 }


### PR DESCRIPTION
Guys!
A user can login into Kovan, then for X reason switch to Mainnet and start making transactions to an empty address on mainnet (Metamask won't say it should revert).
I have not had time to locally test this, but it wouldn't hurt to have an extra checking before signing the TXs.